### PR TITLE
Building image with scratch and amzn2 and publish to AWS ECR Public

### DIFF
--- a/.aws/amzn2.Dockerfile
+++ b/.aws/amzn2.Dockerfile
@@ -1,0 +1,27 @@
+
+ARG BASE_IMAGE=public.ecr.aws/amazonlinux/amazonlinux:2
+ARG VERSION
+ARG GIT_COMMIT
+ARG DATE
+ARG TARGETARCH
+
+FROM $BASE_IMAGE as update
+RUN yum upgrade -y;\
+    yum install -y shadow-utils;\
+    groupadd -r -g 1001 exporter;\
+    useradd -g 1001 -M -r -s /bin/bash exporter;\
+    yum history undo latest -y;\
+    find /var/tmp -name "*.rpm" -print -delete ;\
+    find /tmp -name "*.rpm" -print -delete	;\
+    yum autoremove -y; \
+    yum clean packages; yum clean headers; yum clean metadata; yum clean all; rm -rfv /var/cache/yum
+
+FROM update as intermediate
+
+USER 1001:1001
+ENTRYPOINT [ "/usr/bin/nginx-prometheus-exporter" ]
+
+
+FROM intermediate as container
+ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem /etc/ssl/certs/
+COPY nginx-prometheus-exporter /usr/bin

--- a/.aws/buildspec_image.yml
+++ b/.aws/buildspec_image.yml
@@ -1,0 +1,45 @@
+---
+# Buildspec for building docker image.
+version: 0.2
+env:
+  shell: /bin/bash
+  variables:
+    GO_VERSION: 1.16
+    PUBLIC_REGISTRY: public.ecr.aws/compose-x
+    VERSION: 0.9.0
+    DOCKER_BUILDKIT: 1
+
+phases:
+  install:
+    runtime-versions:
+      golang: "$(echo $GO_VERSION)"
+    commands:
+      - REGISTRY_URI=${PUBLIC_REGISTRY}/
+      - python -m pip install pip -U; python -m pip install aws-sam-cli -U; python -m pip install docker-compose -U
+      - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${PUBLIC_REGISTRY}
+  build:
+    commands:
+      - GIT_COMMIT=`git rev-parse HEAD`
+      - TAG=${VERSION:-$GIT_COMMIT}
+      - DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+      - echo $VERSION - $DATE - $TAG - $GIT_COMMIT
+      - go mod download
+      - |
+          CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath \
+            -a -ldflags "-s -w -X main.version=${VERSION} \
+            -X main.commit=${GIT_COMMIT} -X main.date=${DATE:-$EPOCH}" \
+            -o nginx-prometheus-exporter .
+
+      - ATTEMPTS=0
+      - docker-compose -f .aws/docker-compose.builds.yml build amzn2
+      - |
+          until [ "${ATTEMPTS}" -ge 5 ]; do
+            docker-compose -f .aws/docker-compose.builds.yml build scratch && break
+            echo Attempt ${ATTEMPTS}
+            ATTEMPTS=$((ATTEMPTS+1))
+            sleep 15
+          done
+      - docker-compose -f .aws/docker-compose.builds.yml push
+
+    finally:
+      - rm -rfv ~/.docker

--- a/.aws/buildspec_manifest.yml
+++ b/.aws/buildspec_manifest.yml
@@ -18,18 +18,18 @@ batch:
         variables:
           VERSION: 0.9.0
           ARCH: amd64
-      buildspec: .cicd/buildspec_image.yml
+      buildspec: .aws/buildspec_image.yml
 
-    - identifier: arm64v8
-      env:
-        type: ARM_CONTAINER
-        image: aws/codebuild/amazonlinux2-aarch64-standard:2.0
-        compute-type: BUILD_GENERAL1_LARGE
-        privileged-mode: true
-        variables:
-          ARCH: arm64v8
-          VERSION: 0.9.0
-      buildspec: .cicd/buildspec_image.yml
+#    - identifier: arm64v8
+#      env:
+#        type: ARM_CONTAINER
+#        image: aws/codebuild/amazonlinux2-aarch64-standard:2.0
+#        compute-type: BUILD_GENERAL1_LARGE
+#        privileged-mode: true
+#        variables:
+#          ARCH: arm64v8
+#          VERSION: 0.9.0
+#      buildspec: .aws/buildspec_image.yml
 
     - identifier: manifest
       env:
@@ -37,7 +37,7 @@ batch:
         privileged-mode: true
       depend-on:
         - amd64
-        - arm64v8
+#        - arm64v8
 
 phases:
   install:
@@ -46,12 +46,11 @@ phases:
       - REGISTRY_URI=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION:-$AWS_DEFAULT_REGION}.amazonaws.com
       - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin ${REGISTRY_URI}
       - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${PUBLIC_REGISTRY}
-      - if ! [ -z ${CODEBUILD_RESOLVED_SOURCE_VERSION+x} ]; then COMMIT_HASH=${CODEBUILD_RESOLVED_SOURCE_VERSION::7}; fi
 
   build:
     commands:
       - |
-          for ARCH in "amd64" "arm64v8"; do
+          for ARCH in "amd64"; do
             TAG=${VERSION}-${ARCH}
             echo TAG is $TAG
 
@@ -61,9 +60,10 @@ phases:
             docker push ${PUBLIC_REGISTRY}/${REPOSITORY_NAME}:${TAG}
           done
 
-      - docker manifest create ${PUBLIC_REGISTRY}/${REPOSITORY_NAME}:${VERSION}
-          --amend ${PUBLIC_REGISTRY}/${REPOSITORY_NAME}:${VERSION}-amd64
-          --amend ${PUBLIC_REGISTRY}/${REPOSITORY_NAME}:${VERSION}-arm64v8
+      - |
+          docker manifest create ${PUBLIC_REGISTRY}/${REPOSITORY_NAME}:${VERSION} \
+            --amend ${PUBLIC_REGISTRY}/${REPOSITORY_NAME}:${VERSION}-amd64
+#          --amend ${PUBLIC_REGISTRY}/${REPOSITORY_NAME}:${VERSION}-arm64v8
       - docker manifest push ${PUBLIC_REGISTRY}/${REPOSITORY_NAME}:${SUFFIX}
 
     finally:

--- a/.aws/buildspec_manifest.yml
+++ b/.aws/buildspec_manifest.yml
@@ -6,6 +6,7 @@ env:
     PUBLIC_REGISTRY: public.ecr.aws/compose-x
     DOCKER_CLI_EXPERIMENTAL: enabled
     REPOSITORY_NAME: nginx-prometheus-exporter
+    VERSION: 0.9.0
 
 batch:
   fast-fail: true

--- a/.aws/buildspec_manifest.yml
+++ b/.aws/buildspec_manifest.yml
@@ -1,0 +1,69 @@
+version: 0.2
+env:
+  shell: /bin/bash
+  variables:
+    USE_EPOCH: 0
+    PUBLIC_REGISTRY: public.ecr.aws/compose-x
+    DOCKER_CLI_EXPERIMENTAL: enabled
+    REPOSITORY_NAME: nginx-prometheus-exporter
+
+batch:
+  fast-fail: true
+  build-graph:
+    - identifier: amd64
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        privileged-mode: true
+        variables:
+          VERSION: 0.9.0
+          ARCH: amd64
+      buildspec: .cicd/buildspec_image.yml
+
+    - identifier: arm64v8
+      env:
+        type: ARM_CONTAINER
+        image: aws/codebuild/amazonlinux2-aarch64-standard:2.0
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          ARCH: arm64v8
+          VERSION: 0.9.0
+      buildspec: .cicd/buildspec_image.yml
+
+    - identifier: manifest
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        privileged-mode: true
+      depend-on:
+        - amd64
+        - arm64v8
+
+phases:
+  install:
+    commands:
+      - if [ -z ${AWS_ACCOUNT_ID+x} ]; then AWS_ACCOUNT_ID=$(aws sts get-caller-identity | jq -r .Account); fi
+      - REGISTRY_URI=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION:-$AWS_DEFAULT_REGION}.amazonaws.com
+      - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin ${REGISTRY_URI}
+      - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${PUBLIC_REGISTRY}
+      - if ! [ -z ${CODEBUILD_RESOLVED_SOURCE_VERSION+x} ]; then COMMIT_HASH=${CODEBUILD_RESOLVED_SOURCE_VERSION::7}; fi
+
+  build:
+    commands:
+      - |
+          for ARCH in "amd64" "arm64v8"; do
+            TAG=${VERSION}-${ARCH}
+            echo TAG is $TAG
+
+            echo Publish from ${REGISTRY_URI}/{REPOSITORY_NAME}:${TAG} to ${PUBLIC_REGISTRY}/${REPOSITORY_NAME}:${TAG}
+            docker pull ${REGISTRY_URI}/${REPOSITORY_NAME}:${TAG}
+            docker tag  ${REGISTRY_URI}/${REPOSITORY_NAME}:${TAG} ${PUBLIC_REGISTRY}/${REPOSITORY_NAME}:${TAG}
+            docker push ${PUBLIC_REGISTRY}/${REPOSITORY_NAME}:${TAG}
+          done
+
+      - docker manifest create ${PUBLIC_REGISTRY}/${REPOSITORY_NAME}:${VERSION}
+          --amend ${PUBLIC_REGISTRY}/${REPOSITORY_NAME}:${VERSION}-amd64
+          --amend ${PUBLIC_REGISTRY}/${REPOSITORY_NAME}:${VERSION}-arm64v8
+      - docker manifest push ${PUBLIC_REGISTRY}/${REPOSITORY_NAME}:${SUFFIX}
+
+    finally:
+      - rm -rfv ~/.docker

--- a/.aws/codebuild_release.yml
+++ b/.aws/codebuild_release.yml
@@ -1,0 +1,224 @@
+---
+Description: >-
+  Pipeline to release Lambda layers publicly when new release is created
+
+Metadata:
+  Author: https://github.com/johnpreston
+
+Parameters:
+  RepositoryOrganization:
+    Type: String
+
+  RepositoryProvider:
+    Type: String
+    AllowedValues:
+      - GitHub
+      - CodeCommit
+    Default: GitHub
+  RepositoryName:
+    Type: String
+
+  BuildLogsRetentionDays:
+    Type: Number
+    AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+    Default: 14
+
+  ReferenceBranchName:
+    Type: String
+    Default: main
+
+  DockerBuildspecFile:
+    Type: String
+    Default: .cicd/buildspec_manifest.yml
+
+  LayersBuildSpecFile:
+    Type: String
+    Default: .cicd/buildspec_layers.yml
+
+  PublicFilesBucket:
+    Type: String
+
+  ArtifactsBucket:
+    Type: String
+
+Mappings:
+  RepoUrlPrefixes:
+    GitHub:
+      Prefix: https://github.com/
+
+Conditions:
+  UseGitHub: !Equals [ !Ref RepositoryProvider, 'GitHub']
+  UseCodeCommit: !Equals [ !Ref RepositoryProvider, 'CodeCommit']
+
+Resources:
+  BuildLogsGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub 'codebuild/pr-builds/${RepositoryName}'
+      RetentionInDays: !Ref BuildLogsRetentionDays
+  CodeBuildRole:
+    Type: AWS::IAM::Role
+    Properties:
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/ReadOnlyAccess
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/ResourceGroupsandTagEditorReadOnlyAccess
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - !Sub 'codebuild.${AWS::URLSuffix}'
+      Policies:
+        - PolicyName: ContentAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: S3ObjectsAccess
+                Effect: Allow
+                Action:
+                  - s3:PutObject*
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:s3:::${PublicFilesBucket}/*"
+                  - !Sub "arn:${AWS::Partition}:s3:::${ArtifactsBucket}/*"
+              - Sid: S3BucketsAccess
+                Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:s3:::${PublicFilesBucket}"
+                  - !Sub "arn:${AWS::Partition}:s3:::${ArtifactsBucket}"
+              - Sid: CloudWatchLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource:
+                  - !Sub '${BuildLogsGroup.Arn}'
+              - Sid: CodeBuildReportsAccess
+                Effect: Allow
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/*'
+                Action:
+                  - codebuild:UpdateReportGroup
+                  - codebuild:CreateReportGroup
+                  - codebuild:CreateReport
+                  - codebuild:UpdateReport
+                  - codebuild:BatchPut*
+              - Sid: CodeBuildBatch
+                Effect: Allow
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:*'
+                Action:
+                  - codebuild:StartBuild
+                  - codebuild:RetryBuild
+              - Sid: ECRAuthAndGetFromAny
+                Effect: Allow
+                Resource:
+                  - "*"
+                Action:
+                  - "ecr:GetAuthorizationToken"
+                  - "ecr:BatchGetImage"
+                  - "ecr:BatchCheckLayerAvailability"
+                  - "ecr:GetDownloadUrlForLayer"
+              - Sid: ECRPublishToAnyPrivateRepo
+                Effect: Allow
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/*"
+                Action:
+                  - "ecr:InitiateLayerUpload"
+                  - "ecr:UploadLayerPart"
+                  - "ecr:CompleteLayerUpload"
+                  - "ecr:PutImage"
+
+              - Sid: PublicEcrAuth
+                Effect: Allow
+                Resource:
+                  - "*"
+                Action: [
+                    "ecr-public:GetAuthorizationToken",
+                    "sts:GetServiceBearerToken",
+                    "ecr-public:BatchCheckLayerAvailability",
+                    "ecr-public:GetRepositoryPolicy",
+                    "ecr-public:DescribeRepositories",
+                    "ecr-public:DescribeRegistries",
+                    "ecr-public:DescribeImages",
+                    "ecr-public:DescribeImageTags",
+                    "ecr-public:GetRepositoryCatalogData",
+                    "ecr-public:GetRegistryCatalogData",
+                ]
+
+              - Sid: PublicEcrPublish
+                Effect: Allow
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:ecr-public::${AWS::AccountId}:repository/*"
+                Action: [
+                    "ecr-public:InitiateLayerUpload",
+                    "ecr-public:UploadLayerPart",
+                    "ecr-public:CompleteLayerUpload",
+                    "ecr-public:PutImage"
+                ]
+
+  DockerImagesBuild:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub "docker-publish-${RepositoryName}"
+      ServiceRole: !GetAtt 'CodeBuildRole.Arn'
+      Description: !Sub 'Builds and publishes nginx-prometheus-exporter'
+      LogsConfig:
+        CloudWatchLogs:
+          GroupName: !Ref BuildLogsGroup
+          Status: ENABLED
+          StreamName: docker-builds
+      BadgeEnabled: True
+      Artifacts:
+        Type: NO_ARTIFACTS
+      BuildBatchConfig:
+        CombineArtifacts: False
+        Restrictions:
+          ComputeTypesAllowed:
+            - BUILD_GENERAL1_SMALL
+            - BUILD_GENERAL1_MEDIUM
+            - BUILD_GENERAL1_LARGE
+          MaximumBuildsAllowed: 10
+        ServiceRole: !GetAtt 'CodeBuildRole.Arn'
+        TimeoutInMins: 60
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/standard:5.0
+        Type: LINUX_CONTAINER
+        EnvironmentVariables:
+          - Name: PUBLIC_FILES_BUCKET
+            Type: PLAINTEXT
+            Value: !Ref PublicFilesBucket
+      Source:
+        Type: GITHUB
+        ReportBuildStatus: True
+        Location: !If
+          - UseGitHub
+          - !Sub 'https://github.com/${RepositoryOrganization}/${RepositoryName}'
+          - !Sub 'https://codecommit.${AWS::Region}.${AWS::URLSuffix}'
+        InsecureSsl: False
+        BuildSpec: !Ref DockerBuildspecFile
+      Triggers:
+        Webhook: True
+        BuildType: BUILD_BATCH
+        FilterGroups:
+          - - Type: EVENT
+              Pattern: "PULL_REQUEST_MERGED"
+              ExcludeMatchedPattern: False
+            - Type: HEAD_REF
+              Pattern: '^refs/heads/.*$'
+              ExcludeMatchedPattern: False
+            - Type: BASE_REF
+              Pattern: !Sub '^refs/heads/${ReferenceBranchName}$'
+              ExcludeMatchedPattern: False
+          - - Type: EVENT
+              Pattern: "PUSH"
+              ExcludeMatchedPattern: False
+            - Type: HEAD_REF
+              Pattern: !Sub '^refs/tags/v.*$'
+              ExcludeMatchedPattern: False

--- a/.aws/docker-compose.builds.yml
+++ b/.aws/docker-compose.builds.yml
@@ -1,0 +1,26 @@
+---
+# Docker compose file for the purpose of building images
+version: "3.8"
+services:
+  scratch:
+    build:
+      dockerfile: .aws/scratch.Dockerfile
+      context: ../
+      args:
+        ARCH: "${ARCH}"
+        DATE: ${DATE}
+        VERSION: 0.9.0
+        TARGETARCH: ${ARCH}
+    image: ${REGISTRY_URI}nginx/nginx-prometheus-exporter:${TAG}-${ARCH:-amd64}
+
+  amzn2:
+    build:
+      dockerfile: .aws/amzn2.Dockerfile
+      context: ../
+      args:
+        ARCH: "${ARCH}"
+        BASE_IMAGE: public.ecr.aws/amazonlinux/amazonlinux:2.0.20210721.2
+        DATE: ${DATE}
+        VERSION: 0.9.0
+        TARGETARCH: ${ARCH}
+    image: ${REGISTRY_URI}nginx-prometheus-exporter:${TAG}-${ARCH:-amd64}

--- a/.aws/scratch.Dockerfile
+++ b/.aws/scratch.Dockerfile
@@ -1,0 +1,23 @@
+
+ARG VERSION
+ARG GIT_COMMIT
+ARG DATE
+ARG TARGETARCH
+ARG BASE_IMAGE=golang:1.16
+
+FROM $BASE_IMAGE as base
+ARG VERSION
+ARG GIT_COMMIT
+ARG DATE
+ARG TARGETARCH
+
+WORKDIR /go/src/github.com/nginxinc/nginx-prometheus-exporter
+
+FROM scratch as intermediate
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+USER 1001:1001
+ENTRYPOINT [ "/usr/bin/nginx-prometheus-exporter" ]
+
+
+FROM intermediate as container
+COPY nginx-prometheus-exporter /usr/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 # the binary
 nginx-prometheus-exporter
 dist/
+*~


### PR DESCRIPTION
### Proposed changes
Adds AWS Codebuild settings, AWS CFN template for AWS CodeBuild.
This builds the prometheus exporter in two architectures and publishes a manifest for version 0.9.0
